### PR TITLE
Added hosts/port information for EU Control Plane

### DIFF
--- a/modules/ROOT/pages/servers-create-eu.adoc
+++ b/modules/ROOT/pages/servers-create-eu.adoc
@@ -40,8 +40,8 @@ There are two Static IPs that needs to be whitelisted to access the mule-manager
 [%header,cols="2*a"]
 |===
 |Name |IP Address
-|*mule-manager.anypoint.mulesoft.com* |18.195.19.18
-|*mule-manager.anypoint.mulesoft.com* |18.194.245.32
+|*mule-manager.eu1.anypoint.mulesoft.com* |18.195.19.18
+|*mule-manager.eu1.anypoint.mulesoft.com* |18.194.245.32
 |===
 
 *Dynamic IPs*

--- a/modules/ROOT/pages/servers-create-eu.adoc
+++ b/modules/ROOT/pages/servers-create-eu.adoc
@@ -22,7 +22,7 @@ In your network, you might need to whitelist ports, IP Addresses, and hostnames 
 
 For EU Control Plane, you must whitelist the following ports, IP addresses, and hostnames:
 
-*Ports*
+=== Ports
 
 [%header,cols="2*a"]
 |===
@@ -34,7 +34,7 @@ For EU Control Plane, you must whitelist the following ports, IP addresses, and 
 |*runtime-manager.eu1.anypoint.mulesoft.com* | 443
 |===
 
-*Static IP Addresses*
+=== Static IP Addresses
 
 There are two static IP addresses that must be whitelisted to access the `mule-manager.eu1.anypoint.mulesoft.com` hostname:
 
@@ -45,13 +45,15 @@ There are two static IP addresses that must be whitelisted to access the `mule-m
 |*mule-manager.eu1.anypoint.mulesoft.com* |18.194.245.32
 |===
 
-*Dynamic IPs*
+=== Dynamic IPs
 
 Some IP addresses used by Anypoint services are automatically assigned by the underlying cloud infrastructure, and therefore, might change in the future. For this reason, you should not implement a whitelist based on a specific IP address assigned to Anypoint services.
 
+=== Hostnames for Layer 7 Firewall Rules
+
 Many firewall devices allow you to define Layer 7 Firewall Rules, in which you can filter by destination name or application type.
 
-Include the following hostnames in your Layer 7 Firewall rules:
+Include the following hostnames in your Layer 7 firewall rules:
 
 [%header,cols="1*a"]
 |===

--- a/modules/ROOT/pages/servers-create-eu.adoc
+++ b/modules/ROOT/pages/servers-create-eu.adoc
@@ -16,7 +16,55 @@ The procedures for creating a server are similar to those for creating a server 
 
 This flag ensures that the server connects to Runtime Manager in the EU control plane. When you click Add Server in the  Runtime Manager > Servers tab, Runtime Manager in the EU control plane automatically inserts this flag in the generated script.
 
+== Ports IPs and hostnames to Whitelist
+
+In your network, you may need to whitelist the hostnames and ports of various parts of the Anypoint Platform to allow the Runtime Manager Agent in a customer-hosted Mule runtime to communicate with the MuleSoft-managed online Anypoint Platform APIs and services. See the xref:runtime-manager::installing-and-configuring-runtime-manager-agent.adoc["Ports IPs and hostnames to Whitelist" sectiom the To Install and Configure the Runtime Manager Agent documentation] for general information.
+
+For the EU Control Plane these tables show you the ports or IPs/hostnames to add to your whitelists instead of the once defined in the general documentation.
+
+*Ports*
+
+[%header,cols="2*a"]
+|===
+|Name |Port
+|*eu1.anypoint.mulesoft.com* | 443
+|*mule-manager.eu1.anypoint.mulesoft.com* | 443
+|*analytics-ingest.eu1.anypoint.mulesoft.com* |  443
+|*arm-auth-proxy.prod-eu.msap.io* |  443
+|===
+
+*Static IPs*
+
+There are two Static IPs that needs to be whitelisted to access the mule-manager.eu1.anypoint.mulesoft.com hostname.
+
+[%header,cols="2*a"]
+|===
+|Name |IP Address
+|*mule-manager.anypoint.mulesoft.com* |18.195.19.18
+|*mule-manager.anypoint.mulesoft.com* |18.194.245.32
+|===
+
+*Dynamic IPs*
+
+Some of the IP addresses used by Anypoint services are assigned automatically by the underlying cloud infrastructure, and hence we can't guarantee that they are not going to change in the future.
+
+For this reason, you should not implement a whitelist based on the specific IP addresses being assigned to Anypoint services.
+
+Nowadays, many firewall devices allow you to define Layer 7 Firewall Rules, where you could be able to filter by destination name or application type.
+
+The hostnames that you should include in your Layer 7 Firewall rules include:
+
+[%header,cols="1*a"]
+|===
+|Hostname
+|*eu1.anypoint.mulesoft.com* 
+|*analytics-ingest.eu1.anypoint.mulesoft.com*
+|*arm-auth-proxy.prod-eu.msap.io*
+|===
+
+
 == See Also
 
 * xref:runtime-manager::servers-create.adoc[To Create a Server in Runtime Manager (Hybrid)]
+* xref:runtime-manager::installing-and-configuring-runtime-manager-agent.adoc[To Install and Configure the Runtime Manager Agent documentation]
 * xref:platform-access-eu.adoc[To Access the EU Control Plane]

--- a/modules/ROOT/pages/servers-create-eu.adoc
+++ b/modules/ROOT/pages/servers-create-eu.adoc
@@ -31,6 +31,7 @@ For the EU Control Plane these tables show you the ports or IPs/hostnames to add
 |*mule-manager.eu1.anypoint.mulesoft.com* | 443
 |*analytics-ingest.eu1.anypoint.mulesoft.com* |  443
 |*arm-auth-proxy.prod-eu.msap.io* |  443
+|*runtime-manager.eu1.anypoint.mulesoft.com* | 443
 |===
 
 *Static IPs*
@@ -60,6 +61,7 @@ The hostnames that you should include in your Layer 7 Firewall rules include:
 |*eu1.anypoint.mulesoft.com* 
 |*analytics-ingest.eu1.anypoint.mulesoft.com*
 |*arm-auth-proxy.prod-eu.msap.io*
+|*runtime-manager.eu1.anypoint.mulesoft.com*
 |===
 
 

--- a/modules/ROOT/pages/servers-create-eu.adoc
+++ b/modules/ROOT/pages/servers-create-eu.adoc
@@ -23,7 +23,6 @@ In your network, you might need to whitelist ports, IP Addresses, and hostnames 
 For EU Control Plane, you must whitelist the following ports, IP addresses, and hostnames:
 
 === Ports
-
 [%header,cols="2*a"]
 |===
 |Name |Port
@@ -35,7 +34,6 @@ For EU Control Plane, you must whitelist the following ports, IP addresses, and 
 |===
 
 === Static IP Addresses
-
 There are two static IP addresses that must be whitelisted to access the `mule-manager.eu1.anypoint.mulesoft.com` hostname:
 
 [%header,cols="2*a"]
@@ -45,12 +43,10 @@ There are two static IP addresses that must be whitelisted to access the `mule-m
 |*mule-manager.eu1.anypoint.mulesoft.com* |18.194.245.32
 |===
 
-=== Dynamic IPs
-
+=== Dynamic IP Addresses
 Some IP addresses used by Anypoint services are automatically assigned by the underlying cloud infrastructure, and therefore, might change in the future. For this reason, you should not implement a whitelist based on a specific IP address assigned to Anypoint services.
 
 === Hostnames for Layer 7 Firewall Rules
-
 Many firewall devices allow you to define Layer 7 Firewall Rules, in which you can filter by destination name or application type.
 
 Include the following hostnames in your Layer 7 firewall rules:

--- a/modules/ROOT/pages/servers-create-eu.adoc
+++ b/modules/ROOT/pages/servers-create-eu.adoc
@@ -16,11 +16,11 @@ The procedures for creating a server are similar to those for creating a server 
 
 This flag ensures that the server connects to Runtime Manager in the EU control plane. When you click Add Server in the  Runtime Manager > Servers tab, Runtime Manager in the EU control plane automatically inserts this flag in the generated script.
 
-== Ports IPs and hostnames to Whitelist
+== Ports, IP Addresses, and Hostnames to Whitelist
 
-In your network, you may need to whitelist the hostnames and ports of various parts of the Anypoint Platform to allow the Runtime Manager Agent in a customer-hosted Mule runtime to communicate with the MuleSoft-managed online Anypoint Platform APIs and services. See the xref:runtime-manager::installing-and-configuring-runtime-manager-agent.adoc["Ports IPs and hostnames to Whitelist" sectiom the To Install and Configure the Runtime Manager Agent documentation] for general information.
+In your network, you might need to whitelist ports, IP Addresses, and hostnames of various parts of the Anypoint Platform to allow the Runtime Manager Agent in a customer-hosted Mule runtime to communicate with MuleSoft-managed Anypoint Platform APIs and services. See xref:runtime-manager::rtm-agent-whitelists.adoc[Ports, IP Addresses, and Hostnames to Whitelist] section of the To Install and Configure the Runtime Manager Agent documentation for general information.
 
-For the EU Control Plane these tables show you the ports or IPs/hostnames to add to your whitelists instead of the once defined in the general documentation.
+For EU Control Plane, you must whitelist the following ports, IP addresses, and hostnames:
 
 *Ports*
 
@@ -34,9 +34,9 @@ For the EU Control Plane these tables show you the ports or IPs/hostnames to add
 |*runtime-manager.eu1.anypoint.mulesoft.com* | 443
 |===
 
-*Static IPs*
+*Static IP Addresses*
 
-There are two Static IPs that needs to be whitelisted to access the mule-manager.eu1.anypoint.mulesoft.com hostname.
+There are two static IP addresses that must be whitelisted to access the `mule-manager.eu1.anypoint.mulesoft.com` hostname:
 
 [%header,cols="2*a"]
 |===
@@ -47,13 +47,11 @@ There are two Static IPs that needs to be whitelisted to access the mule-manager
 
 *Dynamic IPs*
 
-Some of the IP addresses used by Anypoint services are assigned automatically by the underlying cloud infrastructure, and hence we can't guarantee that they are not going to change in the future.
+Some IP addresses used by Anypoint services are automatically assigned by the underlying cloud infrastructure, and therefore, might change in the future. For this reason, you should not implement a whitelist based on a specific IP address assigned to Anypoint services.
 
-For this reason, you should not implement a whitelist based on the specific IP addresses being assigned to Anypoint services.
+Many firewall devices allow you to define Layer 7 Firewall Rules, in which you can filter by destination name or application type.
 
-Nowadays, many firewall devices allow you to define Layer 7 Firewall Rules, where you could be able to filter by destination name or application type.
-
-The hostnames that you should include in your Layer 7 Firewall rules include:
+Include the following hostnames in your Layer 7 Firewall rules:
 
 [%header,cols="1*a"]
 |===


### PR DESCRIPTION
The general runtime manager documentation only lists hosts, IP and ports for the US Control Plane. Added EU Control Plane information in this document.